### PR TITLE
feat: add web UI for workflow engine

### DIFF
--- a/easy-workflow-1.0.4/workflow/web_api/Launcher.go
+++ b/easy-workflow-1.0.4/workflow/web_api/Launcher.go
@@ -5,13 +5,16 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-/*开启工作流引擎WebApi	参数说明:
+/*
+开启工作流引擎WebApi	参数说明:
 engine: *gin.Engine gin框架(github.com/gin-gonic/gin)
 GinMode可选项: debug | release
 addr 监听地址与端口,如"localhost:8080"
 */
-func StartWebApi(engine *gin.Engine, ApiBaseUrl string, ShowSwaggerDoc bool,SwaggerUrl string, addr string) {
-	e := NewRouter(engine, ApiBaseUrl, ShowSwaggerDoc,SwaggerUrl)
+func StartWebApi(engine *gin.Engine, ApiBaseUrl string, ShowSwaggerDoc bool, SwaggerUrl string, addr string) {
+	e := NewRouter(engine, ApiBaseUrl, ShowSwaggerDoc, SwaggerUrl)
+	// register embedded static UI
+	registerUI(e)
 	e.Run(addr)
 
 	//如何使用swagger生成文档

--- a/easy-workflow-1.0.4/workflow/web_api/static/index.html
+++ b/easy-workflow-1.0.4/workflow/web_api/static/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Easy Workflow UI</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2em; }
+    button { margin-right: 1em; }
+    pre { background: #f5f5f5; padding: 1em; }
+  </style>
+</head>
+<body>
+  <h1>Easy Workflow UI</h1>
+  <div>
+    <button onclick="listDefs()">List Definitions</button>
+    <button onclick="listTasks()">Todo Tasks</button>
+    <button onclick="startExample()">Start Example</button>
+  </div>
+  <pre id="output"></pre>
+  <script>
+  async function listDefs() {
+    const res = await fetch('/process/def/list');
+    const data = await res.json();
+    document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+  }
+  async function listTasks() {
+    const res = await fetch('/process/task/todo');
+    const data = await res.json();
+    document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+  }
+  async function startExample() {
+    const res = await fetch('/process/inst/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({"proc_def_id":1, "operator":"system"})
+    });
+    const data = await res.json();
+    document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+  }
+  </script>
+</body>
+</html>

--- a/easy-workflow-1.0.4/workflow/web_api/ui.go
+++ b/easy-workflow-1.0.4/workflow/web_api/ui.go
@@ -1,0 +1,20 @@
+package web_api
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+//go:embed static/*
+var uiFiles embed.FS
+
+func registerUI(engine *gin.Engine) {
+	sub, err := fs.Sub(uiFiles, "static")
+	if err != nil {
+		return
+	}
+	engine.StaticFS("/ui", http.FS(sub))
+}


### PR DESCRIPTION
## Summary
- add embedded static web UI for easy-workflow engine
- expose UI at /ui for interacting with process APIs

## Testing
- `cd easy-workflow-1.0.4 && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c537bc878832983f9887c61f7459c